### PR TITLE
feat: uninstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ const { install } = require('lmify')
 await install('package-name')
 ```
 
+### `uninstall(package|packages)`
+
+Uninstall one or more packages in rootDir using the preferred package manager.
+
+```js
+const { uninstall } = require('lmify')
+
+await uninstall('package-name')
+```
+
 ### `setPackageManager(name)`
 
 Set preferred package manager to use. By default, it will be guessed.

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default class LMIFY {
       return
     }
 
-    const [ grant ] = await Promise.all([
+    const [grant] = await Promise.all([
       this._grant(packages),
       this.init()
     ])
@@ -72,6 +72,31 @@ export default class LMIFY {
     }
 
     return this.packageManager.install(packages)
+  }
+
+  async uninstall(packages) {
+    if (!packages) {
+      return
+    }
+
+    if (!Array.isArray(packages)) {
+      packages = [packages]
+    }
+
+    if (!packages.length) {
+      return
+    }
+
+    const [grant] = await Promise.all([
+      this._grant(packages),
+      this.init()
+    ])
+
+    if (!grant) {
+      return
+    }
+
+    return this.packageManager.uninstall(packages)
   }
 }
 

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -50,4 +50,8 @@ export class PackageManager {
   install(packages) {
     return this.getPackageManager().install(packages)
   }
+
+  uninstall(packages) {
+    return this.getPackageManager().uninstall(packages)
+  }
 }

--- a/src/package-managers/nop.js
+++ b/src/package-managers/nop.js
@@ -6,4 +6,8 @@ export class Nop {
   install() {
     return Promise.resolve()
   }
+
+  uninstall() {
+    return Promise.resolve()
+  }
 }

--- a/src/package-managers/npm.js
+++ b/src/package-managers/npm.js
@@ -16,4 +16,11 @@ export class NPM {
       ...packages
     ])
   }
+
+  uninstall(packages) {
+    return this.workspace.exec('npm', [
+      'uninstall',
+      ...packages
+    ])
+  }
 }

--- a/src/package-managers/yarn.js
+++ b/src/package-managers/yarn.js
@@ -15,4 +15,11 @@ export class Yarn {
       ...packages
     ])
   }
+
+  uninstall(packages) {
+    return this.workspace.exec('yarn', [
+      'remove',
+      ...packages
+    ])
+  }
 }

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -1,0 +1,25 @@
+import path from 'path'
+import fs from 'fs-extra'
+import LMIFY from '../src/index'
+
+for (const name of ['npm', 'yarn']) {
+  test('Install with ' + name, async () => {
+    const rootDir = path.join(__dirname, 'fixtures', name)
+
+    const lmify = new LMIFY({
+      rootDir,
+      stdout: 'ignore',
+      stderr: 'ignore'
+    })
+
+    await lmify.install(['is-nan', 'std-env'])
+
+    expect(await fs.exists(path.join(rootDir, 'node_modules', 'is-nan'))).toBe(true)
+    expect(await fs.exists(path.join(rootDir, 'node_modules', 'std-env'))).toBe(true)
+
+    await lmify.uninstall(['is-nan', 'std-env'])
+
+    expect(await fs.exists(path.join(rootDir, 'node_modules', 'is-nan'))).toBe(false)
+    expect(await fs.exists(path.join(rootDir, 'node_modules', 'std-env'))).toBe(false)
+  }, 60000)
+}

--- a/types/lmify.d.ts
+++ b/types/lmify.d.ts
@@ -16,6 +16,7 @@ declare class Lmify {
 
   // commands
   install(packages: string[]): Promise<void> | execa.ExecaReturns
+  uninstall(packages: string[]): Promise<void> | execa.ExecaReturns
 }
 
 declare var lmify: Lmify;


### PR DESCRIPTION
## About

I added a new uninstall command.
This will do `npm uninstall` or `yarn remove`.

## Changes

- [x] Implement uninstall to new surface API
- [x] Add new surface API description to document
- [x] Add type definition to uninstall command
- [x] Update and write tests