### PR TITLE
fix: fix `setRootDir` function type

### DIFF
--- a/types/lmify.d.ts
+++ b/types/lmify.d.ts
@@ -8,7 +8,7 @@ declare class Lmify {
 
   // options
   setPackageManager(name: 'npm' | 'yarn'): void
-  setRootDir(): void
+  setRootDir(path: string): void
 
   // permissions
   addGranter(granter: () => Promise<boolean>): void


### PR DESCRIPTION
so typescript doesn't error.

I was able to make it work via @ts-ignore:

```
  // @ts-ignore wrong type on upstream
  lmify.setRootDir(lambdaPath);
```

fixes #47 